### PR TITLE
Fix docker-compose up startup

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -2,7 +2,7 @@
 
 # Configure these to match your Couchbase cluster configuration.  Best practice is not to use the Administrator user but
 # instead to create one with more limited access - e.g just data read/write on the travel-sample bucket.
-couchbase.host = "localhost"
+couchbase.host = "db"
 couchbase.username = "Administrator"
 couchbase.password = "password"
 
@@ -23,3 +23,6 @@ play.server.http.port="8080"
 # CSRF is where the server injects a unique token into POST forms which can be validated on submission.
 # As the frontend application is a separate project, this backend cannot inject this token, so we disable CSRF.
 play.filters.disabled += "play.filters.csrf.CSRFFilter"
+
+# don't write a pidfile, as this is containerized
+play.server.pidfile.path=/dev/null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,11 @@ services:
     ports:
       - "8091-8095:8091-8095"
       - "11210:11210"
-    expose: # expose ports 8091 & 8094 to other containers (mainly for backend)
+    expose:
       - "8091"
+      - "8092"
+      - "8093"
       - "8094"
-    container_name: couchbase-sandbox-7.0.0-beta
+      - "8095"
+      - "11210"
+    container_name: try-cb-db


### PR DESCRIPTION
 * pidfile.path to /dev/null to prevent it interfering with containerized startup
 * host set to `db` to optimize for this happy path
     (if we wanted to keep localhost, we could alternatively override this in
      the docker-compose.yml?
      But as docker-compose up *is* the happy path, there's no problem with the
      other methods having to specify it (and the mix-and-match.yml already does)
 * expose some more ports (this may not be necessary, but I've found it useful
   in local dev so kept that in)